### PR TITLE
Support exposure control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED
     camera_info_manager
     image_transport
     sensor_msgs
+    std_msgs
     std_srvs
 )
 

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -152,7 +152,7 @@ public:
     service_start_ = node_.advertiseService("start_capture", &UsbCamNode::service_start_cap, this);
     service_stop_ = node_.advertiseService("stop_capture", &UsbCamNode::service_stop_cap, this);
 
-    // subscribe
+    // subscribe exposure control topics
     sub_exposure_auto_ = node_.subscribe("exposure_auto", 1, &UsbCamNode::exposureAutoCallback, this);
     sub_exposure_absolute_ = node_.subscribe("exposure_absolute", 1, &UsbCamNode::exposureAbsoluteCallback, this);
 

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -40,8 +40,8 @@
 #include <camera_info_manager/camera_info_manager.h>
 #include <sensor_msgs/image_encodings.h>
 #include <sstream>
-#include <std_msgs/Int32.h>
 #include <std_msgs/Bool.h>
+#include <std_msgs/Int32.h>
 #include <std_srvs/Empty.h>
 
 namespace usb_cam {

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <depend>ffmpeg</depend>
   <depend>image_transport</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <exec_depend>v4l-utils</exec_depend>
 </package>


### PR DESCRIPTION
Issue https://github.com/seqsense/robotics-software-sprint-backlog/issues/7

Add subscribers for `~/exposure_auto` and `~/exposure_absolute` topics, and set msgs to v4l parameter.