### PR TITLE
Fix 90ccw rot

### DIFF
--- a/include/usb_cam/rotate.h
+++ b/include/usb_cam/rotate.h
@@ -146,7 +146,7 @@ void rotate(const uint8_t *src, uint8_t *dst, const int row, const int col, cons
       {
         for (int c = 0; c < ch; c++)
         {
-          dst[(row * j + i) * ch + c] = src[(col * i + j) * ch + c];
+          dst[(row * (col - 1 - j) + i) * ch + c] = src[(col * i + j) * ch + c];
         }
       }
     }

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -181,7 +181,10 @@ public:
     }
     else
     {
-      ROS_WARN("Invalild rotate code: [%s]. No rotation will be applied.", rotate_code_str.c_str());
+      if (rotate_code_str != "")
+      {
+        ROS_WARN("Invalild rotate code: [%s]. No rotation will be applied.", rotate_code_str.c_str());
+      }
       rotate_code_ = ROTATE_NONE;
     }
 


### PR DESCRIPTION
This PR fixes an issue with the 90CCW rotation. The image was wrongly flipped vertically.

This PR also suppress an unnecessary warning that showed up when no rotation code is specified. 